### PR TITLE
Potential fix for code scanning alert no. 5: Database query built from user-controlled sources

### DIFF
--- a/app.js
+++ b/app.js
@@ -214,7 +214,7 @@ try {
     } else {
       try {
         const bookingId = req.body.bookingId;
-        await Booking.updateOne({ _id: bookingId, userId: req.session.user._id }, { $set: { status: 'cancelled' } });
+        await Booking.updateOne({ _id: { $eq: bookingId }, userId: req.session.user._id }, { $set: { status: 'cancelled' } });
         res.redirect('/booking-details');
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/docker-casestudy/security/code-scanning/5](https://github.com/venkateshpabbati/docker-casestudy/security/code-scanning/5)

To fix the problem, we need to ensure that the `bookingId` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This ensures that the user input is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
